### PR TITLE
Make library usable via jitpack.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,29 @@ A Kotlin Multiplatform image manipulation library based on Android's Bitmap.
 [![License: MPL-2.0](https://img.shields.io/github/license/mihonapp/bitmap.kt?labelColor=27303D&color=0877d2)](/LICENSE)
 [![Discord server](https://img.shields.io/discord/1195734228319617024.svg?label=&labelColor=6A7EC2&color=7389D8&logo=discord&logoColor=FFFFFF)](https://discord.gg/mihon)
 
+<div align="left">
+
+### Usage
+Add `jitpack.io` to your dependencies:
+```build.gradle.kts
+dependencies {
+    maven("https://www.jitpack.io")
+}
+```
+
+Add a dependency. Platform libraries (*-jvm, *-android) will be automatically included into the corresponding source sets.
+> `initial_release` here is a tag. use `main-SNAPSHOT` to use the latest version from branch `main`, use `9a99a3c` to refer to a certain commit hash.
+```build.gradle.kts
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation("com.github.mihonapp.bitmap~kt:bitmap:initial_release")
+        }
+    }
+}
+```
+</div>
+
 ### Repositories
 
 [![mihonapp/mihon - GitHub](https://github-readme-stats.vercel.app/api/pin/?username=mihonapp&repo=mihon&bg_color=161B22&text_color=c9d1d9&title_color=0877d2&icon_color=0877d2&border_radius=8&hide_border=true)](https://github.com/mihonapp/mihon/)

--- a/bitmap/build.gradle.kts
+++ b/bitmap/build.gradle.kts
@@ -2,17 +2,22 @@ plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.spotless)
+    `maven-publish`
 }
 
 kotlin {
     jvmToolchain(8)
     androidTarget {
+        publishLibraryVariants("release")
         compilations.all {
             kotlinOptions {
                 freeCompilerArgs += "-Xexpect-actual-classes"
                 jvmTarget = JavaVersion.VERSION_1_8.toString()
             }
+
         }
+
+
     }
     jvm {
         compilations.all {
@@ -43,7 +48,15 @@ android {
     defaultConfig {
         minSdk = 21
     }
+
+    publishing {
+        multipleVariants {
+            allVariants()
+            withSourcesJar()
+        }
+    }
 }
+
 
 spotless {
     kotlin {

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+# kmm requires AGP 7.0+ which can't be used with jdk8. minimal and recommended java versions for AGP 8.3 is 17.
+jdk:
+    - openjdk17


### PR DESCRIPTION
Added publishing plugin and config so this lib can be used by connecting it via jitpack.io. Also added short description of the usage. Added a release tag to simplify usage.

Tested on my own project and seems to be working.